### PR TITLE
Add GitHub Pages deployment notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ here's an app for building concept graphs out of a list of tagged documents. htt
 "#knowledgegraph #knowledgemanagement #ai #designthinking"
 "
 https://www.linkedin.com/feed/update/urn%3Ali%3AugcPost%3A7261881256538173440
+
+
+## Deployment
+For tips on running this project on GitHub Pages, see [github-pages-deployment.md](github-pages-deployment.md).
+

--- a/github-pages-deployment.md
+++ b/github-pages-deployment.md
@@ -1,0 +1,29 @@
+# Deploying the Tag Concurrence Graph on GitHub Pages
+
+This repository was originally designed to run on Replit with a small Flask back‑end. GitHub Pages only serves static content, so the Flask server cannot run directly on Pages. Below are a few approaches to make the project available on GitHub Pages and suggestions for setting up the environment.
+
+## 1. Convert to a purely static site
+
+- Keep the `templates` and `static` directories, but adapt the code so that data loading and file uploads happen entirely in the browser using JavaScript.
+- Store example JSON files (like `tag_concurrence_graph.json`) in the repository so they can be fetched directly via HTTP.
+- Replace API routes (`/api/network`, `/api/upload`, `/api/export`) with equivalent client‑side logic. For instance, file uploads can be handled by reading the file in the browser and updating the visualization without sending it to a server.
+- Once the app works without the Flask server, commit the static HTML/JS/CSS files in the root or a `docs` folder. GitHub Pages can serve files from the root of the `main` branch or from `/docs`.
+
+## 2. Use GitHub Actions to build the site
+
+If you move the front‑end to a framework like React, you can use an action to build the production bundle and push it to the `gh-pages` branch. Typical steps:
+
+1. In `.github/workflows/` create a workflow that installs Node, runs `npm install && npm run build`, and then deploys using the `actions/deploy-pages` action.
+2. Configure GitHub Pages to serve the `gh-pages` branch.
+
+## 3. Host the Flask back‑end elsewhere
+
+If server features are required, consider hosting the Flask app on a small cloud service (Render, Fly.io, etc.) and use GitHub Pages only for the front‑end files. Update the JavaScript to call the remote API.
+
+## Environment setup
+
+- Python dependencies are listed in `pyproject.toml`. Use Python 3.11 or later.
+- For local development with Flask, run `python main.py` and visit `http://localhost:5000`.
+- To serve the static version locally, you can use a simple HTTP server: `python -m http.server` from the directory containing `index.html`.
+
+Choose the option that best fits the project goals. For a simple demo or personal site, converting everything to static files is often the quickest way to deploy on GitHub Pages.


### PR DESCRIPTION
## Summary
- add instructions for deploying this Flask-based app on GitHub Pages
- link from README to the new deployment notes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68553e451cc08332b1ea1780dd1acb79