### PR TITLE
Fix script order on index page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -168,6 +168,6 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="{{ url_for('static', filename='js/controls.js') }}"></script>
 <script src="{{ url_for('static', filename='js/graph.js') }}"></script>
+<script src="{{ url_for('static', filename='js/controls.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- load graph.js before controls.js on the homepage
- ensure trailing newline in index.html

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855432ed8d083328b67d7093956c032