### PR TITLE
Check static folder before copying

### DIFF
--- a/build_static.py
+++ b/build_static.py
@@ -20,8 +20,13 @@ def build():
         with open(out_path, 'w', encoding='utf-8') as f:
             f.write(rendered)
 
-    # Copy static files
-    shutil.copytree(app.static_folder, os.path.join(output_dir, 'static'), dirs_exist_ok=True)
+    # Copy static files if available
+    if app.static_folder:
+        shutil.copytree(
+            app.static_folder,
+            os.path.join(output_dir, 'static'),
+            dirs_exist_ok=True,
+        )
 
     # Copy example JSON datasets
     for fname in ['tag_concurrence_graph.json', 'complex_project_management_graph.json']:


### PR DESCRIPTION
## Summary
- safeguard the build script to only copy static files when a static folder is configured
- keep tests passing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855432c2b508332888a9144301a2953