### PR TITLE
Fix asset paths for GitHub Pages

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Key concepts in my reading list: a visualiser for document tags</title>
     <link href="https://cdn.replit.com/agent/bootstrap-agent-dark-theme.min.css" rel="stylesheet">
-    <link href="{{ url_for('static', filename='css/styles.css') }}" rel="stylesheet">
+    <link href="static/css/styles.css" rel="stylesheet">
     <!-- Load Cytoscape and extensions in correct order -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.26.0/cytoscape.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -80,7 +80,7 @@
             <p class="text-muted mb-3">Lawrence rowland, with the help of Replit and ChatGPT</p>
         </div>
     </div>
-    <img src="{{ url_for('static', filename='images/Howgills.png') }}" class="background-image" alt="Howgills">
+    <img src="static/images/Howgills.png" class="background-image" alt="Howgills">
 </div>
 
 <!-- Modals -->
@@ -168,6 +168,6 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="{{ url_for('static', filename='js/graph.js') }}"></script>
-<script src="{{ url_for('static', filename='js/controls.js') }}"></script>
+<script src="static/js/graph.js"></script>
+<script src="static/js/controls.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- use relative paths for static assets so GitHub Pages serves them correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b036aaac8332b0ded7be45f2ee66