### PR TITLE
Add separate complex page and default dataset support

### DIFF
--- a/static/js/controls.js
+++ b/static/js/controls.js
@@ -22,6 +22,7 @@ async function fetchDataset(name) {
 document.addEventListener('DOMContentLoaded', async function() {
     // Initialize dataset buttons first
     const datasetButtons = document.querySelectorAll('[data-dataset]');
+    const defaultDataset = document.body.dataset.defaultDataset || 'lawrence';
     
     // Wait for Cytoscape initialization
     while (!cy) {
@@ -30,14 +31,16 @@ document.addEventListener('DOMContentLoaded', async function() {
 
     try {
         console.log("Setting initial dataset...");
-        // Set Lawrence dataset button as active
+        // Highlight the default dataset button if present
         datasetButtons.forEach(btn => btn.classList.remove('active'));
-        const lawrenceButton = document.querySelector('[data-dataset="lawrence"]');
-        lawrenceButton.classList.add('active');
+        const defaultButton = document.querySelector(`[data-dataset="${defaultDataset}"]`);
+        if (defaultButton) {
+            defaultButton.classList.add('active');
+        }
 
-        console.log("Loading Lawrence dataset...");
-        // Load Lawrence dataset by default using the helper
-        originalData = await fetchDataset('lawrence');
+        console.log("Loading dataset: ", defaultDataset);
+        // Load dataset specified on the body element
+        originalData = await fetchDataset(defaultDataset);
         console.log("Loaded dataset with nodes:", originalData.nodes.length);
         
         // Clear any existing elements
@@ -305,9 +308,10 @@ document.addEventListener('DOMContentLoaded', async function() {
         }
     });
 
-    // File upload handling
+    // File upload handling (only if upload form exists)
     const uploadForm = document.getElementById('uploadForm');
-    uploadForm.addEventListener('submit', async function(e) {
+    if (uploadForm) {
+        uploadForm.addEventListener('submit', async function(e) {
         e.preventDefault();
         const fileInput = document.getElementById('jsonFile');
         const file = fileInput.files[0];
@@ -334,7 +338,7 @@ document.addEventListener('DOMContentLoaded', async function() {
             cy.elements().remove();
             
             // Get and load new network data
-            originalData = await fetchDataset('lawrence');
+            originalData = await fetchDataset(defaultDataset);
             
             // Add new elements
             cy.add(originalData);
@@ -354,5 +358,6 @@ document.addEventListener('DOMContentLoaded', async function() {
         }
         
         fileInput.value = ''; // Reset file input
-    });
+        });
+    }
 });

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,7 +16,7 @@
     <script src="https://unpkg.com/cose-base/cose-base.js"></script>
     <script src="https://unpkg.com/cytoscape-fcose/cytoscape-fcose.js"></script>
 </head>
-<body>
+<body data-default-dataset="{{ default_dataset|default('lawrence') }}">
     {% block content %}{% endblock %}
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     {% block scripts %}{% endblock %}

--- a/templates/complex.html
+++ b/templates/complex.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% set default_dataset = 'lawrence' %}
+{% set default_dataset = 'complex' %}
 
 {% block content %}
 <div class="container-fluid">
@@ -7,7 +7,7 @@
         <div class="col-md-3 p-3 control-panel">
             <h4>Key concepts in my reading list: a visualiser for document tags</h4>
             <p>
-                <a href="complex.html">View complex project graph</a>
+                <a href="index.html">View reading list graph</a>
             </p>
             <!-- Information Buttons -->
             <div class="mb-3">


### PR DESCRIPTION
## Summary
- add a new `complex.html` page
- remove dataset switcher and upload form from both pages
- configure pages with a `data-default-dataset` attribute
- update JS controls to read the default dataset and handle missing upload form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68568e421e0c8332933dd28a4de43a42