### PR TITLE
Switch export to client-side download

### DIFF
--- a/static/js/controls.js
+++ b/static/js/controls.js
@@ -258,28 +258,17 @@ document.addEventListener('DOMContentLoaded', async function() {
                 layout: currentLayout
             };
 
-            // Send data to server
-            const response = await fetch('/api/export', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(exportData)
-            });
+            // Create a Blob locally instead of sending to the server
+            const jsonString = JSON.stringify(exportData, null, 2);
+            const blob = new Blob([jsonString], { type: 'application/json' });
 
-            if (!response.ok) {
-                throw new Error('Network response was not ok');
-            }
-
-            // Get the blob from the response
-            const blob = await response.blob();
-            
-            // Create a download link and trigger it
+            // Generate filename with timestamp
+            const ts = new Date().toISOString().replace(/[:.]/g, '-');
             const url = window.URL.createObjectURL(blob);
             const a = document.createElement('a');
             a.style.display = 'none';
             a.href = url;
-            a.download = response.headers.get('Content-Disposition').split('filename=')[1];
+            a.download = `network_export_${ts}.json`;
             document.body.appendChild(a);
             a.click();
             window.URL.revokeObjectURL(url);

--- a/templates/complex.html
+++ b/templates/complex.html
@@ -148,7 +148,7 @@
                     <li>Switch between different layouts using the dropdown</li>
                     <li>Filter connections by weight using the buttons</li>
                     <li>Toggle node labels on/off</li>
-                    <li>Export your current view</li>
+                    <li>Download your current view as a JSON file</li>
                     <li>Upload custom JSON data</li>
                 </ul>
             </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -148,7 +148,7 @@
                     <li>Switch between different layouts using the dropdown</li>
                     <li>Filter connections by weight using the buttons</li>
                     <li>Toggle node labels on/off</li>
-                    <li>Export your current view</li>
+                    <li>Download your current view as a JSON file</li>
                     <li>Upload custom JSON data</li>
                 </ul>
             </div>

--- a/templates/modals.html
+++ b/templates/modals.html
@@ -75,7 +75,7 @@
                     <li>Switch between different layouts using the dropdown</li>
                     <li>Filter connections by weight using the buttons</li>
                     <li>Toggle node labels on/off</li>
-                    <li>Export your current view</li>
+                    <li>Download your current view as a JSON file</li>
                     <li>Upload custom JSON data</li>
                 </ul>
             </div>


### PR DESCRIPTION
## Summary
- download the exported network locally from the client instead of POSTing to the server
- update instructions in the feature list to mention downloading a JSON file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685696520f948332866d41a2270c87d8