### PR TITLE
Improve dataset load error handling

### DIFF
--- a/static/js/controls.js
+++ b/static/js/controls.js
@@ -30,8 +30,14 @@ document.addEventListener('DOMContentLoaded', async function() {
 
     async function loadDataset(name) {
         console.log('Loading dataset:', name);
-        originalData = await fetchDataset(name);
-        console.log('Loaded dataset with nodes:', originalData.nodes.length);
+        try {
+            originalData = await fetchDataset(name);
+            console.log('Loaded dataset with nodes:', originalData.nodes.length);
+        } catch (err) {
+            console.error('Failed to load dataset:', err);
+            alert('Failed to load dataset. Please ensure the JSON files are present.');
+            return;
+        }
 
         cy.elements().remove();
         cy.add(originalData);


### PR DESCRIPTION
## Summary
- add a try/except around dataset loading and display a user alert if graph data isn't available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856fa60120883329fe19bd4ad30a39f