### PR TITLE
Handle large dataset performance

### DIFF
--- a/static/js/controls.js
+++ b/static/js/controls.js
@@ -56,6 +56,15 @@ document.addEventListener('DOMContentLoaded', async function() {
         cy.elements().remove();
         cy.add(originalData);
 
+        // Heavy datasets can stall the fcose layout. Switch to a
+        // simpler layout for the large reading list graph by default.
+        if (name === 'lawrence') {
+            const layoutSelect = document.getElementById('layoutSelect');
+            if (layoutSelect.value === 'fcose') {
+                layoutSelect.value = 'concentric';
+            }
+        }
+
         applyLayout();
         applyCommunityStyling();
 


### PR DESCRIPTION
## Summary
- adjust loading logic for the reading list graph so heavy graphs default to the concentric layout

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858063ecf3c8332aaab5d26dab30c08