### PR TITLE
Fix page titles and navigation links

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Key concepts in my reading list: a visualiser for document tags</title>
+    <title>{{ page_title|default('Key concepts in my reading list: a visualiser for document tags') }}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="static/css/styles.css" rel="stylesheet">
     <!-- Load Cytoscape and extensions in correct order -->

--- a/templates/complex.html
+++ b/templates/complex.html
@@ -1,13 +1,14 @@
 {% extends "base.html" %}
 {% set default_dataset = 'complex' %}
+{% set page_title = 'Typical Relationships on complex projects' %}
 
 {% block content %}
 <div class="container-fluid">
     <div class="row">
         <div class="col-md-3 p-3 control-panel">
-            <h4>Key concepts in my reading list: a visualiser for document tags</h4>
+            <h4>Typical Relationships on complex projects</h4>
             <p>
-                <a href="index.html">View reading list graph</a>
+                <a href="index.html">view reading list graph instead</a>
             </p>
             <!-- Information Buttons -->
             <div class="mb-3">

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% set default_dataset = 'lawrence' %}
+{% set page_title = 'Key concepts in my reading list: a visualiser for document tags' %}
 
 {% block content %}
 <div class="container-fluid">
@@ -7,7 +8,7 @@
         <div class="col-md-3 p-3 control-panel">
             <h4>Key concepts in my reading list: a visualiser for document tags</h4>
             <p>
-                <a href="complex.html">View project management graph</a>
+                <a href="complex.html">view project management graph instead</a>
             </p>
             <!-- Information Buttons -->
             <div class="mb-3">


### PR DESCRIPTION
## Summary
- add dynamic page title support in `base.html`
- update complex graph with new title and navigation link
- update reading list graph link wording

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68587d75ecd08332b278f1f61fca6677